### PR TITLE
feature(BLOG): create blog index and pages

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -16,9 +16,14 @@ module.exports = {
       },
       {
         id: 3,
+        name: `Blog`,
+        link: `/blog`
+      },
+      {
+        id: 4,
         name: `Join Our Slack`,
         link: `/slack`
-      }
+      },
     ]
   },
   plugins: [

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,11 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
 			name: `slug`,
 			value: slug,
 		})
+		createNodeField({
+			node,
+			name: `pageType`,
+			value: slug.includes("/blog/") ? `blog-post` : `markdown-page`,
+		})
 	}
 }
 
@@ -18,23 +23,82 @@ exports.createPages = ({ graphql, actions }) => {
 
 	return graphql(`
     {
-      allMarkdownRemark {
+      allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
         edges {
           node {
             fields {
               slug
+              pageType
             }
           }
         }
       }
     }
   `).then(result => {
-		result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+		const {
+			blogPosts,
+			otherPages,
+		} = result.data.allMarkdownRemark.edges.reduce(
+			(acc, edge) => {
+				if (edge.node.fields.pageType === "blog-post") {
+					acc.blogPosts.push(edge)
+				} else {
+					acc.otherPages.push(edge)
+				}
+				return acc
+			},
+			{ blogPosts: [], otherPages: [] }
+		)
+
+		// Create feature-requests page and any other markdown files in the pages directory
+		otherPages.forEach(({ node }) => {
 			createPage({
-				path: node.fields.slug, component: path.resolve(`./src/templates/blog-post.js`), context: {
+				path: node.fields.slug,
+				component: path.resolve(`./src/templates/markdown-page.js`),
+				context: {
 					// Data passed to context is available
 					// in page queries as GraphQL variables.
 					slug: node.fields.slug,
+				},
+			})
+		})
+
+		// Create blog post pages and define pagination rules
+		const postsPerPage = 6
+		const numPages = Math.ceil(blogPosts.length / postsPerPage)
+
+		blogPosts.forEach(({ node }, index) => {
+			const next =
+				index === blogPosts.length - 1 ? null : blogPosts[index + 1].node
+			const previous = index === 0 ? null : blogPosts[index - 1].node
+
+			createPage({
+				path: node.fields.slug,
+				component: path.resolve(`./src/templates/blog-post.js`),
+				context: {
+					// Data passed to context is available
+					// in page queries as GraphQL variables.
+					slug: node.fields.slug,
+					// give each page it's context in the paginitation
+					previous,
+					next,
+					index,
+					numPages,
+					postsPerPage,
+				},
+			})
+		})
+
+		// create blog list pages
+		Array.from({ length: numPages }).forEach((_, i) => {
+			createPage({
+				path: i === 0 ? `/blog` : `/blog/${i + 1}`,
+				component: path.resolve(`./src/templates/blog-index.js`),
+				context: {
+					limit: postsPerPage,
+					skip: i * postsPerPage,
+					numPages,
+					currentPage: i + 1,
 				},
 			})
 		})

--- a/src/blog/all-about-ecommerce.md
+++ b/src/blog/all-about-ecommerce.md
@@ -1,0 +1,8 @@
+---
+title: "All about ecommerce"
+date: "2019/09/12/"
+author: "Michelle Gatsby"
+blurb: "Using shopify with Gatsby"
+---
+
+here we are at our fourth test post

--- a/src/blog/astronaut.md
+++ b/src/blog/astronaut.md
@@ -1,0 +1,8 @@
+---
+title: "Why an astronaut?"
+date: "2020/08/14"
+author: "Tommy Gatsby"
+blurb: "The story of the gatsby astronaut logo"
+---
+
+Wow love it

--- a/src/blog/first-post.md
+++ b/src/blog/first-post.md
@@ -1,0 +1,8 @@
+---
+title: "First post"
+date: "2019/08/12"
+author: "Michelle Gatsby"
+blurb: "The first post for our new blog"
+---
+
+here we are at test post one

--- a/src/blog/gatsby-configs.md
+++ b/src/blog/gatsby-configs.md
@@ -1,0 +1,8 @@
+---
+title: "Gatsby Configs"
+date: "2019/08/13"
+author: "Tommy Gatsby"
+blurb: "A quick guide to Gatsby Configs"
+---
+
+Wow I love gatsby!

--- a/src/blog/images-in-gatsby.md
+++ b/src/blog/images-in-gatsby.md
@@ -1,0 +1,8 @@
+---
+title: "Images in gatsby"
+date: "2019/08/14"
+author: "Michelle Gatsby"
+blurb: "Gatsby images rule"
+---
+
+Gatsby is great

--- a/src/blog/our-fifth-post.md
+++ b/src/blog/our-fifth-post.md
@@ -1,0 +1,8 @@
+---
+title: "Post 5 of the Gatsby NYC blog"
+date: "2020/08/12"
+author: "Michelle Gatsby"
+blurb: "The fifth post for our new blog"
+---
+
+What a great meetup group

--- a/src/blog/server-side-rendering.md
+++ b/src/blog/server-side-rendering.md
@@ -1,0 +1,8 @@
+---
+title: "What is Server-side Rendering?"
+date: "2020/08/13"
+author: "Michelle Gatsby"
+blurb: "It's part what makes gatsby so fast. Let's learn about it"
+---
+
+Server-rendering?! Sick!

--- a/src/blog/styled-components.md
+++ b/src/blog/styled-components.md
@@ -1,0 +1,10 @@
+---
+title: "Cool stuff in styled-components with Gatsby"
+date: "2020/11/12"
+author: "Michelle Gatsby"
+blurb: "Every wondered what the big deal is with styled-components? Let's learn together."
+---
+
+## test post 2
+
+I love styled-components

--- a/src/components/BlogPostCard.js
+++ b/src/components/BlogPostCard.js
@@ -1,0 +1,35 @@
+/* react */
+import React from "react"
+import Link from "./common/Link"
+import styled from "styled-components"
+import theme from "../theme"
+
+export default ({ post }) => (
+  <Container theme={theme}>
+    <BlogHeader>
+      <h3>{post.title}</h3>
+      <p>
+        by {post.author} | {post.date}
+      </p>
+    </BlogHeader>
+    <p>{post.blurb}</p>
+    <Link to={post.slug}>Read More</Link>
+  </Container>
+)
+
+const BlogHeader = styled.div`
+  h3 {
+    margin-bottom: 10px;
+  }
+
+  p {
+    font-size: 0.8em;
+    line-height: 0.8em;
+  }
+`
+
+const Container = styled.div`
+  background: ${props => props.theme.colors.white};
+  border-bottom: 1px solid ${props => props.theme.colors.grey};
+  padding: 1.45rem 0;
+`

--- a/src/templates/blog-index.js
+++ b/src/templates/blog-index.js
@@ -1,0 +1,80 @@
+/* react */
+import React from "react"
+import styled from "styled-components"
+
+/* GraphQL */
+import { graphql } from "gatsby"
+
+/* components */
+import Layout from "../layout"
+import SEO from "../components/seo"
+import BlogPostCard from "../components/BlogPostCard"
+import Link from "../components/common/Link"
+
+export default props => {
+  const blogPostCards = props.data.allMarkdownRemark.edges.map(edge => (
+    <BlogPostCard
+      post={{ ...edge.node.frontmatter, ...edge.node.fields }}
+      key={edge.node.fields.slug}
+    />
+  ))
+
+  const { currentPage, numPages } = props.pageContext
+  const nextPage = currentPage + 1
+  const prevPage = currentPage < 3 ? "" : currentPage - 1
+  const nextDisabled = currentPage === numPages
+  const prevDisabled = currentPage === 1
+
+  return (
+    <Layout>
+      <SEO title="Blog - Gatsby NYC" />
+      {blogPostCards.length ? (
+        blogPostCards
+      ) : (
+        <h2>Come back soon for some exciting Gatsby content...</h2>
+      )}
+      <BottomNav>
+        <Link to={`/blog/${prevPage}`} className={prevDisabled && "disabled"}>
+          {"<<"} Previous
+        </Link>
+        <Link to={`/blog/${nextPage}`} className={nextDisabled && "disabled"}>
+          Next >>
+        </Link>
+      </BottomNav>
+    </Layout>
+  )
+}
+
+const BottomNav = styled.div`
+  margin-top: 3rem;
+  text-align: center;
+
+  .disabled {
+    display: none;
+  }
+`
+
+export const blogListQuery = graphql`
+  query blogListQuery($skip: Int!, $limit: Int!) {
+    allMarkdownRemark(
+      filter: { fields: { slug: { regex: "/blog/" } } }
+      sort: { fields: [frontmatter___date], order: DESC }
+      limit: $limit
+      skip: $skip
+    ) {
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+            date
+            author
+            blurb
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,19 +1,59 @@
 import React from "react"
+import styled from "styled-components"
 import { graphql } from "gatsby"
 import Layout from "../layout"
+import Link from "../components/common/Link"
 
-export default ({ data }) => {
-  const post = data.markdownRemark
+export default props => {
+  const post = props.data.markdownRemark
+  const nextPost = ((props.pageContext.next || {}).fields || {}).slug
+  const prevPost = ((props.pageContext.previous || {}).fields || {}).slug
+  const paginationPosition =
+    Math.floor(props.pageContext.index / props.pageContext.postsPerPage) + 1
+  const blogIndexPage =
+    paginationPosition > 1 ? `/blog/${paginationPosition}` : `/blog/`
 
   return (
     <Layout>
+      <BackStyles>
+        <Link to={blogIndexPage}>Back to Blog</Link>
+      </BackStyles>
+
       <div>
         <h1>{post.frontmatter.title}</h1>
         <div dangerouslySetInnerHTML={{ __html: post.html }} />
       </div>
+      <BlogNav>
+        <Link to={prevPost} className={!prevPost && `disabled`}>
+          {"<<"} Previous
+        </Link>
+        |
+        <Link to={nextPost} className={!nextPost && `disabled`}>
+          Next >>
+        </Link>
+      </BlogNav>
     </Layout>
   )
 }
+
+const BlogNav = styled.div`
+  justify-content: space-evenly;
+  margin: 2rem auto;
+  display: flexbox;
+
+  @media (max-width: 400) {
+  }
+
+  a {
+    padding: 1em;
+  }
+  .disabled {
+    display: none;
+  }
+`
+const BackStyles = styled.div`
+  text-align: right;
+`
 
 export const query = graphql`
   query($slug: String!) {

--- a/src/templates/markdown-page.js
+++ b/src/templates/markdown-page.js
@@ -1,0 +1,26 @@
+import React from "react"
+import { graphql } from "gatsby"
+import Layout from "../layout"
+
+export default props => {
+  const post = props.data.markdownRemark
+  return (
+    <Layout>
+      <div>
+        <h1>{post.frontmatter.title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: post.html }} />
+      </div>
+    </Layout>
+  )
+}
+
+export const query = graphql`
+  query($slug: String!) {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      html
+      frontmatter {
+        title
+      }
+    }
+  }
+`


### PR DESCRIPTION
**Changes**

- create blog pages in _gatsby-node.js_ 
- create fake blog pages for testing purposes in _src/blog_
- create blog index page to see all pages
- create blog template to create post pages
- separate out other markdown pages from blog posts in _gatsby-node.js_
- add Blog button to navbar

**To use blog**

Authors will simply add their blog posts as markdown files in the _/src/blog_ directory. They will need to add the following fields to their frontmatter:

- title
- date
- author
- blurb



